### PR TITLE
Fix: 내부 API(/internal) 호출 시 LoginFilter 우회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 allprojects {
     group = 'org.todaybook'
-    version = '1.2.0'
+    version = '1.3.0'
     description = 'org.todaybook.common'
 }
 

--- a/common-mvc/src/main/java/org/todaybook/commonmvc/security/BaseSecurityConfig.java
+++ b/common-mvc/src/main/java/org/todaybook/commonmvc/security/BaseSecurityConfig.java
@@ -188,11 +188,15 @@ public abstract class BaseSecurityConfig {
   }
 
   /**
-   * 내부용 API 경로에 대해 인증 없이 허용할 Matcher 목록을 반환한다.
+   * 내부용 API 경로에 대해 인증/인가를 단순화하기 위한 Matcher 목록을 반환한다.
    *
-   * <p>해당 경로는 Gateway, 배치, 내부 서비스 간 호출 등 신뢰된 네트워크 환경에서 접근되는 엔드포인트를 대상으로 한다.
+   * <p>해당 경로는 Gateway, 배치, 내부 서비스 간 호출 등 VPC 내부의 신뢰된 네트워크 환경에서만 접근되는 엔드포인트를 대상으로 한다.
    *
-   * <p>기본적으로 {@code /internal/**} 경로를 인증 없이 허용하며, 필요 시 하위 클래스에서 오버라이드하여 정책을 변경하거나 비활성화할 수 있다.
+   * <p>기본적으로 {@code /internal/**} 경로를 인증 없이 허용하며, {@link
+   * LoginFilter#shouldNotFilter(jakarta.servlet.http.HttpServletRequest)} 와 함께 내부 호출이 인증 필터 및 인가
+   * 단계에서 모두 차단되지 않도록 하는 이중 안전장치로 동작한다.
+   *
+   * <p>내부 호출을 애플리케이션 레벨에서 보호해야 하는 경우, 이 설정을 제거하거나 하위 클래스에서 오버라이드하여 정책을 변경할 수 있다.
    *
    * @return internal API permitAll 대상 {@link RequestMatcher} 배열
    * @author 김지원

--- a/common-mvc/src/main/java/org/todaybook/commonmvc/security/external/filter/LoginFilter.java
+++ b/common-mvc/src/main/java/org/todaybook/commonmvc/security/external/filter/LoginFilter.java
@@ -52,6 +52,18 @@ public class LoginFilter extends OncePerRequestFilter {
   private static final String HEADER_USER_ROLES = "X-User-Roles";
 
   /**
+   * 내부 서비스 간 호출 전용 경로(/internal/**)에 대해서는 Gateway 인증 헤더 기반 {@link LoginFilter} 적용을 생략합니다.
+   *
+   * <p>/internal/** 엔드포인트는 네트워크 레벨에서 이미 신뢰된 요청이라는 전제 하에 사용되므로, 외부 클라이언트 인증을 위한 LoginFilter를 통과시키지
+   * 않습니다.
+   */
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    String uri = request.getRequestURI();
+    return uri.startsWith("/internal/");
+  }
+
+  /**
    * 요청당 한 번 실행되는 필터 진입점입니다.
    *
    * <p>이미 인증된 요청인 경우 인증 로직을 수행하지 않고 그대로 다음 필터로 전달합니다. 인증되지 않은 요청에 대해서만 Gateway Header 기반 인증을 시도합니다.


### PR DESCRIPTION
## 🛠️ 작업 내용 (Details)
내부 API(/internal) 호출 시 LoginFilter 우회

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)
1.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 v1.3.0

* **Chores**
  * 프로젝트 버전이 1.2.0에서 1.3.0으로 업데이트됨

* **개선사항**
  * 내부 서비스 경로의 인증 처리 메커니즘이 개선되어 시스템 안정성이 향상됨
  * 내부 통신 구간의 보안 정책이 강화됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->